### PR TITLE
New GitHub workflow to auto-update list of contributors

### DIFF
--- a/.github/workflows/auto-update-contributors-readme.yml
+++ b/.github/workflows/auto-update-contributors-readme.yml
@@ -1,0 +1,87 @@
+# GitHub Actions documentation:
+# https://docs.github.com/en/actions
+
+name: Auto-update list of contributors
+
+on:
+  workflow_call:
+    inputs:
+      is_protected:
+        description: Indicate if the branch to be updated is protected.
+        default: true
+        required: false
+        type: boolean
+
+jobs:
+  update_contributors_list:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+
+      - name: Check if a pull request already exists
+        if: ${{ inputs.is_protected == true }}
+        id: find_existing_pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ID_PR="$( \
+            gh api search/issues \
+              --method GET \
+              --raw-field q='repo:${{ github.repository }} type:pr state:open "Auto-update list of contributors" in:title' \
+              --jq '.items.[0].number' \
+          )"
+
+          echo "::set-output name=id_pr_to_close::$ID_PR"
+
+      - name: Close the existing pull request
+        if: ${{ steps.find_existing_pr.outputs.id_pr_to_close }}
+        id: close_existing_pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr close ${{ steps.find_existing_pr.outputs.id_pr_to_close }} \
+            --repo ${{ github.repository }} \
+            --delete-branch
+
+      # https://github.com/akhilmhdh/contributors-readme-action
+      - name: Update the list of contributors in the README file
+        uses: akhilmhdh/contributors-readme-action@v2.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          commit_message: 'chore: auto-update contributors list (GH Action)'
+          committer_username: 'akhilmhdh/contributors-readme-action'
+          is_protected: ${{ inputs.is_protected }}
+          use_username: true
+
+      # The Action `akhilmhdh/contributors-readme-action` creates PRs with a fixed title:
+      # https://github.com/akhilmhdh/contributors-readme-action/blob/v2.3/src/index.js#L169
+      - name: Rename the new PR with a better title
+        if: ${{ inputs.is_protected == true }}
+        id: rename_new_pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sleep 10 # Some delay is needed to make sure GitHub had time to create the new PR
+
+          ID_PR="$( \
+            gh api search/issues \
+              --method GET \
+              --raw-field q='repo:${{ github.repository }} type:pr state:open "contributors readme action update" in:title' \
+              --jq '.items.[0].number' \
+          )"
+
+          gh pr edit $ID_PR \
+            --repo ${{ github.repository }} \
+            --title "Auto-update list of contributors"
+
+          echo "::set-output name=id_new_pr::$ID_PR"
+
+      - name: Comment the previous PR with reference to the new PR
+        if: ${{ steps.close_existing_pr.outcome == 'success' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ steps.find_existing_pr.outputs.id_pr_to_close }} \
+            --repo ${{ github.repository }} \
+            --body "This PR has been replaced by #${{ steps.rename_new_pr.outputs.id_new_pr }} ."

--- a/.github/workflows/auto-update-contributors-readme.yml
+++ b/.github/workflows/auto-update-contributors-readme.yml
@@ -12,88 +12,48 @@ jobs:
     timeout-minutes: 20
     steps:
 
-      - name: Check if the default branch is protected
-        id: default_branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          defaultBranch="$( \
-            gh api /repos/${{ github.repository }} \
-              --method GET \
-              --jq '.default_branch'
-          )"
-
-          isProtected="$( \
-            gh api /repos/${{ github.repository }}/branches/$defaultBranch \
-            --jq '.protected'
-          )"
-
-          echo "::set-output name=is_protected::$isProtected"
-
-      - name: Check if a pull request already exists
-        if: ${{ steps.default_branch.outputs.is_protected == 'true' }}
-        id: find_existing_pr
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          ID_PR="$( \
-            gh api search/issues \
-              --method GET \
-              --raw-field q='repo:${{ github.repository }} type:pr state:open "Auto-update list of contributors" in:title' \
-              --jq '.items.[0].number' \
-          )"
-
-          echo "::set-output name=id_pr_to_close::$ID_PR"
-
-      - name: Close the existing pull request
-        if: ${{ steps.find_existing_pr.outputs.id_pr_to_close }}
-        id: close_existing_pr
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr close ${{ steps.find_existing_pr.outputs.id_pr_to_close }} \
-            --repo ${{ github.repository }} \
-            --delete-branch
-
       # https://github.com/akhilmhdh/contributors-readme-action
       - name: Update the list of contributors in the README file
-        uses: akhilmhdh/contributors-readme-action@v2.3
+        uses: akhilmhdh/contributors-readme-action@v2.3.2
+        id: update_contributors
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           commit_message: 'chore: auto-update contributors list (GH Action)'
           committer_username: 'akhilmhdh/contributors-readme-action'
-          is_protected: ${{ steps.default_branch.outputs.is_protected == 'true' }}
+          pr_title_on_protected: Auto-update list of contributors
           use_username: true
 
-      # The Action `akhilmhdh/contributors-readme-action` creates PRs with a fixed title:
-      # https://github.com/akhilmhdh/contributors-readme-action/blob/v2.3/src/index.js#L169
-      - name: Rename the new PR with a better title
-        if: ${{ steps.default_branch.outputs.is_protected == 'true' }}
-        id: rename_new_pr
+      # The previous step might have created a PR to make the update.
+      # If that's the case, we want to close any previous similar PR, to avoid duplication.
+      - name: 'Close previous pull request (if it exists)'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          sleep 10 # Some delay is needed to make sure GitHub had time to create the new PR
-
-          ID_PR="$( \
+          request="$( \
             gh api search/issues \
               --method GET \
-              --raw-field q='repo:${{ github.repository }} type:pr state:open "contributors readme action update" in:title' \
-              --jq '.items.[0].number' \
+              --raw-field q='repo:${{ github.repository }} type:pr state:open sort:updated-asc "Auto-update list of contributors" in:title' \
           )"
 
-          gh pr edit $ID_PR \
-            --repo ${{ github.repository }} \
-            --title "Auto-update list of contributors"
+          count_pr=$( jq '.total_count' <<< $request )
 
-          echo "::set-output name=id_new_pr::$ID_PR"
+          # We are supposed to have either 1 or 2 PRs:
+          # - One PR:  1 created by the previous step + no existing PR
+          # - Two PRs: 1 created by the previous step + 1 existing PR
+          if [ $count_pr -eq 2 ]; then
 
-      - name: Comment the previous PR with reference to the new PR
-        if: ${{ steps.close_existing_pr.outcome == 'success' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr comment ${{ steps.find_existing_pr.outputs.id_pr_to_close }} \
-            --repo ${{ github.repository }} \
-            --body "This PR has been replaced by #${{ steps.rename_new_pr.outputs.id_new_pr }} ."
+            # PRs are sorted by least recently updated date => the first is the oldest.
+            id_pr_oldest=$( jq '.items[0].number' <<< $request )
+
+            # Comment the oldest PR with a link to the new PR.
+            gh pr comment $id_pr_oldest \
+              --repo ${{ github.repository }} \
+              --body "Replaced by #${{ steps.update_contributors.outputs.pr_id }} ."
+
+            # And finally, close the PR.
+            gh pr close $id_pr_oldest \
+              --repo ${{ github.repository }} \
+              --delete-branch
+
+          fi

--- a/.github/workflows/auto-update-contributors-readme.yml
+++ b/.github/workflows/auto-update-contributors-readme.yml
@@ -5,12 +5,6 @@ name: Auto-update list of contributors
 
 on:
   workflow_call:
-    inputs:
-      is_protected:
-        description: Indicate if the branch to be updated is protected.
-        default: true
-        required: false
-        type: boolean
 
 jobs:
   update_contributors_list:
@@ -18,8 +12,26 @@ jobs:
     timeout-minutes: 20
     steps:
 
+      - name: Check if the default branch is protected
+        id: default_branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          defaultBranch="$( \
+            gh api /repos/${{ github.repository }} \
+              --method GET \
+              --jq '.default_branch'
+          )"
+
+          isProtected="$( \
+            gh api /repos/${{ github.repository }}/branches/$defaultBranch \
+            --jq '.protected'
+          )"
+
+          echo "::set-output name=is_protected::$isProtected"
+
       - name: Check if a pull request already exists
-        if: ${{ inputs.is_protected == true }}
+        if: ${{ steps.default_branch.outputs.is_protected == 'true' }}
         id: find_existing_pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -51,13 +63,13 @@ jobs:
         with:
           commit_message: 'chore: auto-update contributors list (GH Action)'
           committer_username: 'akhilmhdh/contributors-readme-action'
-          is_protected: ${{ inputs.is_protected }}
+          is_protected: ${{ steps.default_branch.outputs.is_protected == 'true' }}
           use_username: true
 
       # The Action `akhilmhdh/contributors-readme-action` creates PRs with a fixed title:
       # https://github.com/akhilmhdh/contributors-readme-action/blob/v2.3/src/index.js#L169
       - name: Rename the new PR with a better title
-        if: ${{ inputs.is_protected == true }}
+        if: ${{ steps.default_branch.outputs.is_protected == 'true' }}
         id: rename_new_pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-update-contributors-readme.yml
+++ b/.github/workflows/auto-update-contributors-readme.yml
@@ -6,6 +6,14 @@ name: Auto-update list of contributors
 on:
   workflow_call:
 
+    # https://github.com/akhilmhdh/contributors-readme-action#optional-parameters
+    inputs:
+      use_username:
+        description: If people should be listed with their username instead of their full name.
+        default: true
+        required: false
+        type: boolean
+
 jobs:
   update_contributors_list:
     runs-on: ubuntu-latest
@@ -22,7 +30,7 @@ jobs:
           commit_message: 'chore: auto-update contributors list (GH Action)'
           committer_username: 'akhilmhdh/contributors-readme-action'
           pr_title_on_protected: Auto-update list of contributors
-          use_username: true
+          use_username: ${{ inputs.use_username }}
 
       # The previous step might have created a PR to make the update.
       # If that's the case, we want to close any previous similar PR, to avoid duplication.

--- a/.github/workflows/auto-update-contributors-readme.yml
+++ b/.github/workflows/auto-update-contributors-readme.yml
@@ -41,7 +41,14 @@ jobs:
           request="$( \
             gh api search/issues \
               --method GET \
-              --raw-field q='repo:${{ github.repository }} type:pr state:open sort:updated-asc author:app/github-actions "Auto-update list of contributors" in:title' \
+              --raw-field q='\
+                repo:${{ github.repository }} \
+                type:pr \
+                state:open \
+                sort:updated-asc \
+                author:app/github-actions \
+                "Auto-update list of contributors" in:title\
+              ' \
           )"
 
           count_pr=$( jq '.total_count' <<< $request )

--- a/.github/workflows/auto-update-contributors-readme.yml
+++ b/.github/workflows/auto-update-contributors-readme.yml
@@ -41,7 +41,7 @@ jobs:
           request="$( \
             gh api search/issues \
               --method GET \
-              --raw-field q='repo:${{ github.repository }} type:pr state:open sort:updated-asc "Auto-update list of contributors" in:title' \
+              --raw-field q='repo:${{ github.repository }} type:pr state:open sort:updated-asc author:app/github-actions "Auto-update list of contributors" in:title' \
           )"
 
           count_pr=$( jq '.total_count' <<< $request )

--- a/.github/workflows/auto-update-list-contributors.yml
+++ b/.github/workflows/auto-update-list-contributors.yml
@@ -15,7 +15,7 @@ on:
         type: boolean
 
 jobs:
-  update_contributors_list:
+  update_contributors:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
### New GitHub workflow to auto-update the list of contributors

When this workflow runs it does:

1. Update the list of contributors

   - By directly pushing a commit on the default branch
   - Or, if the default branch is protected, by creating a pull request

2. If there was already a previous PR
   _This is not executed if the update was made through a commit_

   1. A link to the new PR is posted on the previous PR
   1. And the previous PR is closed

For more details, checkout https://github.com/akhilmhdh/contributors-readme-action .

**Input that can be passed from the caller workflow:**

- `use_username` (optional)
  If contributors should be listed with their username instead of their full name.


### Currently implemented in the repositories

- https://github.com/peopledoc/ember-slugify/pull/156
- https://github.com/peopledoc/ember-reading-time/pull/23
- https://github.com/peopledoc/ember-feature-controls/pull/170
- https://github.com/peopledoc/ember-cli-embedded/pull/174
- https://github.com/peopledoc/ember-cli-deploy-index-json/pull/43
- https://github.com/peopledoc/styledown/pull/150
- https://github.com/peopledoc/eslint-config-peopledoc/pull/94
- https://github.com/peopledoc/broccoli-styledown/pull/55

---

## Notes

- GitHub CLI `gh` is preinstalled on all GitHub-hosted runners
  https://docs.github.com/en/actions/advanced-guides/using-github-cli-in-workflows

  See all included tools for each runner operating system:
  https://github.com/actions/virtual-environments/tree/main/images

  For instance, [the runner Ubuntu 20.04.3 LTS](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md).

- GitHub REST API
  https://docs.github.com/en/rest

- GitHub CLI manual
  https://cli.github.com/manual