### PR TITLE
Add test scenarios `ember-beta` and `ember-canary`

### DIFF
--- a/.github/workflows/js--emberjs-addons-ci.yml
+++ b/.github/workflows/js--emberjs-addons-ci.yml
@@ -16,6 +16,8 @@ on:
           'ember-lts-3.20',
           'ember-lts-3.24',
           'ember-release',
+          'ember-beta',
+          'ember-canary',
           'ember-classic',
           'ember-default-with-jquery',
           'embroider-safe',
@@ -108,10 +110,16 @@ jobs:
     needs: lint_tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    continue-on-error: ${{ matrix.allowed_to_fail || false }}
     strategy:
       fail-fast: false
       matrix:
         try-scenario: ${{ fromJSON(inputs.ember_try_scenarios) }}
+        include:
+          - try-scenario: ember-beta
+            allowed_to_fail: true
+          - try-scenario: ember-canary
+            allowed_to_fail: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
### Add `ember-try` test scenarios `ember-beta` and `ember-canary`

The shared GitHub workflow to lint and tests Ember.js add-ons now includes the `ember-try` scenarios:
- `ember-beta`
- `ember-canary`

They are flagged as "allowed to fail", meaning that, if one or both fail, the whole job won't fail.

> Note: in the YAML file, the name of the key `allowed_to_fail` is arbitrary and could be anything.

Declaring those scenarios as "allowed to fail" in CI's configuration file instead of `ember-try` config file has some advantages:

- If declared in `ember-try` config file, when a test fails it is seen as passed (green) in the CI, while there might have been an error ([example](https://github.com/peopledoc/ember-peopledoc-ui/actions/runs/1453043940))

-  If declared in CI's config file, when a test fails it is seen as failed (red) in the CI, but the whole job won't fail ([example](https://github.com/peopledoc/ember-peopledoc-ui/actions/runs/1453002580))

Because the human is lazy, having failed tests marked as green is not a good idea, people won't actually check if these tests really ran correctly or not.

**What if an add-on does not want to test the scenarios `ember-beta` and `ember-canary`?**

Let's say an add-on overrides the default list of `ember-try` scenarios: (see https://github.com/peopledoc/.github/pull/2)

```yaml
...
jobs:
  org:
    uses: peopledoc/.github/.github/workflows/emberjs-addons-ci.yml@main
    with:
      ember_try_scenarios: "[
        'ember-release',
      ]"
```

This will result in the reusable workflow:

```yaml
  ...
  ember_try:
    ...
    strategy:
      fail-fast: false
      matrix:
        try-scenario:
          - ember-release
        include:
          - try-scenario: ember-beta
            allowed_to_fail: true
          - try-scenario: ember-canary
            allowed_to_fail: true
```

The CI will fail when it will try to start `ember-beta` and `ember-canary` as they are not present in the list of scenarios to run, but that's not important since they are allowed to fail. ([example](https://github.com/peopledoc/ember-cli-embedded/runs/4473047612))